### PR TITLE
Fix: Don't send Content-Type on GET requests (avoids 400 error)

### DIFF
--- a/opnsense-mcp-server.py
+++ b/opnsense-mcp-server.py
@@ -126,7 +126,6 @@ class OPNsenseClient:
         url = f"{self.base_url}/api{endpoint}"
         headers = {
             "Authorization": f"Basic {self.auth_header}",
-            "Content-Type": "application/json",
             "Accept": "application/json"
         }
         


### PR DESCRIPTION
# Pull Request - Fix: Don't send Content-Type header on GET requests (avoids 400 error)

## Description

This pull request fixes an issue where GET requests were being sent with the header `Content-Type: application/json`, causing a `400 Bad Request` error from the OPNsense API (specifically when testing `/core/firmware/status`).

---

## What changed

- The `request()` method in `OPNsenseClient` now only sends `Content-Type: application/json` on **POST** requests.
- No functional change for POST requests.
- GET requests are now fully compatible with endpoints like `/core/firmware/status`.

---

## Use Case

This issue was encountered while using the OPNsense MCP Server in conjunction with **mcp-proxy** (rather than directly with Claude).

In this scenario:

- `configure_opnsense_connection` sends a GET request to `/core/firmware/status` to test connectivity.
- With `Content-Type` included, OPNsense responded with:

```json
{"status":400,"message":"Invalid JSON syntax"}
```

- After applying this patch, the request works as expected (`HTTP 200 OK`).

---

## This fix improves compatibility when using this MCP server with:

- Automation pipelines
- Home automation platforms (e.g. Home Assistant)
- Other MCP clients beyond Claude

---

## Testing

- Manually tested with **mcp-proxy** connected to an OPNsense 25.1.7_4 instance.
- Verified that GET requests to `/core/firmware/status` now succeed.
- Verified that POST requests continue to send `Content-Type` correctly.

---

## Notes

- I am using this server in a slightly extended scenario (**mcp-proxy + Home Assistant**), but this bug affects all GET requests and would appear in any environment.
- This is a minimal, safe fix: no change to existing logic except correct header behavior.